### PR TITLE
Drop "then" from "try/else" clause

### DIFF
--- a/text/0000-try-else-and-drop-then.md
+++ b/text/0000-try-else-and-drop-then.md
@@ -26,6 +26,8 @@ and how the "with" statement conceivably solves the problem. Since in
 some languages exception handling is used for flow control it might
 also be good to talk about this.
 
+The "Try-then blocks" section in the tutorial can be removed.
+
 
 # Drawbacks
 

--- a/text/0000-try-else-and-drop-then.md
+++ b/text/0000-try-else-and-drop-then.md
@@ -19,6 +19,14 @@ addition the "with" statement supports multiple such resources at the
 same time without additional nesting.
 
 
+# How We Teach This
+
+In the documentation we need to talk about what resource management is
+and how the "with" statement conceivably solves the problem. Since in
+some languages exception handling is used for flow control it might
+also be good to talk about this.
+
+
 # Drawbacks
 
 The main drawback is that code that uses "try/else/then" today will

--- a/text/0000-try-else-and-drop-then.md
+++ b/text/0000-try-else-and-drop-then.md
@@ -1,0 +1,31 @@
+- Feature Name: Try, else, no "then"
+- Start Date: 2016-06-10
+- RFC PR:
+- Pony Issue: #291
+
+# Summary
+
+Drop "then" clause from "try/else" clause.
+
+
+# Motivation
+
+The behavior is orthogonal to error handling. It applies in general
+when leaving a code block.
+
+The "with" statement already provides the necessary functionality for
+obtaining and giving up a resource such as a lock or file handle. In
+addition the "with" statement supports multiple such resources at the
+same time without additional nesting.
+
+
+# Drawbacks
+
+The main drawback is that code that uses "try/else/then" today will
+need to be updated to use a "with" block which needs object support in
+the form of a "dispose method".
+
+
+# Unresolved questions
+
+Currently none.

--- a/text/0000-try-else-and-drop-then.md
+++ b/text/0000-try-else-and-drop-then.md
@@ -10,8 +10,8 @@ Drop "then" clause from "try/else" clause.
 
 # Motivation
 
-The behavior is orthogonal to error handling. It applies in general
-when leaving a code block.
+Running a block of code upon scope exit is orthogonal to error
+handling and has more to do with resource management.
 
 The "with" statement already provides the necessary functionality for
 obtaining and giving up a resource such as a lock or file handle. In


### PR DESCRIPTION
Drop "then" clause from "try/else" clause – see [proposal text](https://github.com/malthe/rfcs/blob/try-else-and-drop-then/text/0000-try-else-and-drop-then.md).

See [PR #9](https://github.com/ponylang/rfcs/pull/9) for an extended conversation on the topic.
