### PR TITLE
FFI taming

### DIFF
--- a/text/0000-ffi-taming.md
+++ b/text/0000-ffi-taming.md
@@ -1,0 +1,36 @@
+- Feature Name: (fill me in with a unique ident, my_awesome_feature)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: (leave this empty)
+- Pony Issue: (leave this empty)
+
+# Summary
+
+One para explanation of the feature.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Detailed design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody familiar with the language to understand, and for somebody familiar with the compiler to implement. This should get into specifics and corner-cases, and include examples of how the feature is used.
+
+# How We Teach This
+
+What names and terminology work best for these concepts and why? How is this idea best presented? As a continuation of existing Pony patterns, or as a wholly new one?
+
+Would the acceptance of this proposal mean the Pony guides must be re-organized or altered? Does it change how Pony is taught to new users at any level?
+
+How should this feature be introduced and taught to existing Pony users?
+
+# Drawbacks
+
+Why should we *not* do this?
+
+# Alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Unresolved questions
+
+What parts of the design are still TBD?

--- a/text/0000-ffi-taming.md
+++ b/text/0000-ffi-taming.md
@@ -59,15 +59,16 @@ of the `--safe` flag.
 Just as the tutorial cites "Capability Myths Demolished" there is a certain
 amount of literature to draw from:
 
- - [http://www.combex.com/papers/darpa-review/security-review.html A Security Analysis of the Combex DarpaBrowser Architecure] by David Wagner & Dean Tribble March 4, 2002
+ - [Joe-E: A Security-Oriented Subset of Java](https://people.eecs.berkeley.edu/~daw/papers/joe-e-ndss10.pdf) Adrian Mettler, David Wagner, and Tyler Close. ISOC NDSS 2010.
+ - [A Security Analysis of the Combex DarpaBrowser Architecure](http://www.combex.com/papers/darpa-review/security-review.html) by David Wagner & Dean Tribble March 4, 2002
    - especially section 5.2    Taming the Java Interface.
  - [A Theory of Taming](http://erights.org/elib/legacy/taming.html)
- - [Joe-E: A Security-Oriented Subset of Java](https://people.eecs.berkeley.edu/~daw/papers/joe-e-ndss10.pdf) Adrian Mettler, David Wagner, and Tyler Close. ISOC NDSS 2010.
 
 # Drawbacks
 
   - API churn
-  - additional code review burden
+  - time cost to audit the standard library
+  - additional code review burden going forward
   - possible false sense of security if we don't get it right
 
 # Alternatives

--- a/text/0000-ffi-taming.md
+++ b/text/0000-ffi-taming.md
@@ -78,5 +78,7 @@ amount of literature to draw from:
 
 # Unresolved questions
 
-A review of all FFI calls in the standard library is in order.
+ - Make an exception for logging/tracing?
+   - This is somewhat traditional; e.g. section 6.2 of the DarpaBrowser paper says "The renderer can call a tracing service to output debugging messages."
+ - A review of all FFI calls in the standard library is in order to refine the detailed design.
 

--- a/text/0000-ffi-taming.md
+++ b/text/0000-ffi-taming.md
@@ -1,15 +1,37 @@
-- Feature Name: (fill me in with a unique ident, my_awesome_feature)
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
-- RFC PR: (leave this empty)
-- Pony Issue: (leave this empty)
+- Feature Name: ffi-taming
+- Start Date: 2016-08-30
+- RFC PR:
+- Pony Issue:
 
 # Summary
 
-One para explanation of the feature.
+Apply a uniform taming policy to FFI in the pony standard library
+and document it as a best practice for the community. In brief,
+the policy is to "dominate" all impure FFI calls with AmbientAuth.
 
 # Motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
+The result of such a policy is to remove ad-hoc trust from the FFI boundary,
+resulting in the same safety and robust composition as the rest of pony.
+
+The tutorial currently says:
+
+> What about global variables?
+>
+> They're bad! Because you can get them without either constructing them or being passed them.
+>
+> Global variables are a form of what is called ambient authority. Another form of ambient authority is unfettered access to the file system.
+>
+> Pony has no global variables and no global functions. That doesn't mean all ambient authority is magically gone - we still need to be careful about the file system, for example. Having no globals is necessary, but not sufficient, to eliminate ambient authority.
+
+But actually, we don't need to be careful about the filesystem, at least as
+exposed by the pony files package. It does not provide unfettered access to the filesystem;
+all access is "fettered" directly by AmbientAuth capabilities or indirectly
+by FilePath capabilities.
+
+While we can't magically get rid of all ambient authority, we can feasibly
+get rid of it from the standard library with careful application of object
+capability discipline and we can establish this as a best practice for the community.
 
 # Detailed design
 

--- a/text/0000-ffi-taming.md
+++ b/text/0000-ffi-taming.md
@@ -81,4 +81,6 @@ amount of literature to draw from:
  - Make an exception for logging/tracing?
    - This is somewhat traditional; e.g. section 6.2 of the DarpaBrowser paper says "The renderer can call a tracing service to output debugging messages."
  - A review of all FFI calls in the standard library is in order to refine the detailed design.
-
+   - `term` calls `@ioctl`; perhaps the relevant authority is already explicitly delegated?
+   - `signals` calls `pony_asio_event_create` ...
+     - `ponyint_asio_get_backend()` should perhaps be replaced by storing `asio_backend_t*` in the `AmbientAuth` or `Env`


### PR DESCRIPTION
Apply a uniform taming policy to FFI in the pony standard library and document it as a best practice for the community. In brief, the policy is to "dominate" all impure FFI calls with AmbientAuth.
