### PR TITLE
Method must refer to trait or interface

### DIFF
--- a/text/0000-method-must-refer-to-trait-or-interface.md
+++ b/text/0000-method-must-refer-to-trait-or-interface.md
@@ -5,15 +5,13 @@
 
 # Summary
 
-A public method on an actor or class must implement a declared trait or help complete an interface.
+Public methods on an actor or class must implement a declared trait or help complete an interface.
 
 # Motivation
 
 Since Pony is a statically-typed language, it makes sense to understands its OOP approach as contract-based. This allows the compiler to help the programmer write correct programs.
 
-In Pony, contracts are defined through traits and interfaces. The compiler validates objects against these, but it doesn't check if objects implements more than what's in the contract.
-
-This means that the contract can be changed with the implementation left out of sync.
+In Pony, contracts are defined through traits and interfaces. The compiler validates objects against these, but it doesn't check if objects implement more than what's in the contract (this applies for both traits and interfaces.)
 
 Java optionally provides the ``@Override`` annotation to require that a method overrides a method defined in a superclass and the same annotation can be used (rather confusingly) to require that a method implements a method in a declared trait (but again, the annotation is optional.)
 
@@ -23,7 +21,7 @@ This proposal is for a requirement that all methods defined on a class or actor 
 
 A method is allowed if it implements a method from a declared trait, or if it helps complete a trait – in any other case, it's a compile-time error.
 
-The requirement only affects public methods (those that do not begin with an underscore).
+Note that the requirement only affects public methods (those that do not begin with an underscore).
 
 # How We Teach This
 

--- a/text/0000-method-must-refer-to-trait-or-interface.md
+++ b/text/0000-method-must-refer-to-trait-or-interface.md
@@ -27,7 +27,7 @@ Note that the requirement only affects public methods (those that do not begin w
 
 OOP needs to be talked about in the tutorial. That is, what is Pony's understanding of OOP and how it's different from Smalltalk and other duck-typed OOP languages.
 
-In Erlang, an actor is allowed to ignore incoming messages. This is not how Pony works.
+In Erlang, an actor is allowed to ignore incoming messages. This is not how Pony works. In Pony, an actor messages are methods and are type-checked just like object methods.
 
 # Drawbacks
 

--- a/text/0000-method-must-refer-to-trait-or-interface.md
+++ b/text/0000-method-must-refer-to-trait-or-interface.md
@@ -19,7 +19,7 @@ This proposal is for a requirement that all methods defined on a class or actor 
 
 # Detailed design
 
-A method is allowed if it implements a method from a declared trait, or if it helps complete a trait – in any other case, it's a compile-time error.
+The compiler will support a new flag ``-Wpedantic`` (enabled in Pony's own test suite and encouraged in general) that enables the proposed validation.
 
 Note that the requirement only affects public methods (those that do not begin with an underscore).
 

--- a/text/0000-method-must-refer-to-trait-or-interface.md
+++ b/text/0000-method-must-refer-to-trait-or-interface.md
@@ -5,7 +5,7 @@
 
 # Summary
 
-A public method on an actor or class must implement a declared interface or help complete a trait.
+A public method on an actor or class must implement a declared trait or help complete an interface.
 
 # Motivation
 
@@ -15,13 +15,13 @@ In Pony, contracts are defined through traits and interfaces. The compiler valid
 
 This means that the contract can be changed with the implementation left out of sync.
 
-Java optionally provides the ``@Override`` annotation to require that a method overrides a method defined in a superclass and the same annotation can be used (rather confusingly) to require that a method implements a method in a declared interface (but again, the annotation is optional.)
+Java optionally provides the ``@Override`` annotation to require that a method overrides a method defined in a superclass and the same annotation can be used (rather confusingly) to require that a method implements a method in a declared trait (but again, the annotation is optional.)
 
-This proposal is for a requirement that all methods defined on a class or actor match an interface definition, or help complete a trait. With this requirement there is no need for an annotation such as Java's ``@Override``.
+This proposal is for a requirement that all methods defined on a class or actor match a trait definition, or help complete an interface. With this requirement there is no need for an annotation such as Java's ``@Override``.
 
 # Detailed design
 
-A method is allowed if it implements a method from a declared interface, or if it helps complete a trait – in any other case, it's a compile-time error.
+A method is allowed if it implements a method from a declared trait, or if it helps complete a trait – in any other case, it's a compile-time error.
 
 The requirement only affects public methods (those that do not begin with an underscore).
 

--- a/text/0000-method-must-refer-to-trait-or-interface.md
+++ b/text/0000-method-must-refer-to-trait-or-interface.md
@@ -5,7 +5,7 @@
 
 # Summary
 
-A public method on an actor or class should match a declared interface or contribute to a trait.
+A public method on an actor or class must implement a declared interface or help complete a trait.
 
 # Motivation
 

--- a/text/0000-method-must-refer-to-trait-or-interface.md
+++ b/text/0000-method-must-refer-to-trait-or-interface.md
@@ -27,12 +27,9 @@ The requirement only affects public methods (those that do not begin with an und
 
 # How We Teach This
 
-OOP needs to be talked about in the tutorial. That is, what is Pony's
-understanding of OOP and how it's different from Smalltalk and other
-duck-typed OOP languages.
+OOP needs to be talked about in the tutorial. That is, what is Pony's understanding of OOP and how it's different from Smalltalk and other duck-typed OOP languages.
 
-In Erlang, an actor is allowed to ignore incoming messages. This is
-not how Pony works.
+In Erlang, an actor is allowed to ignore incoming messages. This is not how Pony works.
 
 # Drawbacks
 

--- a/text/0000-method-must-refer-to-trait-or-interface.md
+++ b/text/0000-method-must-refer-to-trait-or-interface.md
@@ -1,0 +1,47 @@
+- Feature Name: Method must refer to trait or interface
+- Start Date: 2016-09-07
+- RFC PR: (leave this empty)
+- Pony Issue: (leave this empty)
+
+# Summary
+
+A public method on an actor or class should match a declared interface or contribute to a trait.
+
+# Motivation
+
+Since Pony is a statically-typed language, it makes sense to understands its OOP approach as contract-based. This allows the compiler to help the programmer write correct programs.
+
+In Pony, contracts are defined through traits and interfaces. The compiler validates objects against these, but it doesn't check if objects implements more than what's in the contract.
+
+This means that the contract can be changed with the implementation left out of sync.
+
+Java optionally provides the ``@Override`` annotation to require that a method overrides a method defined in a superclass and the same annotation can be used (rather confusingly) to require that a method implements a method in a declared interface (but again, the annotation is optional.)
+
+This proposal is for a requirement that all methods defined on a class or actor match an interface definition, or help complete a trait. With this requirement there is no need for an annotation such as Java's ``@Override``.
+
+# Detailed design
+
+A method is allowed if it implements a method from a declared interface, or if it helps complete a trait – in any other case, it's a compile-time error.
+
+The requirement only affects public methods (those that do not begin with an underscore).
+
+# How We Teach This
+
+OOP needs to be talked about in the tutorial. That is, what is Pony's
+understanding of OOP and how it's different from Smalltalk and other
+duck-typed OOP languages.
+
+In Erlang, an actor is allowed to ignore incoming messages. This is
+not how Pony works.
+
+# Drawbacks
+
+Currently none have been identified.
+
+# Alternatives
+
+As presented in the motivation previously, Java handles these concerns differently: with an optional annotation that the compiler is able to validate.
+
+# Unresolved questions
+
+The impact on existing code is currently not known.


### PR DESCRIPTION
A public method on an actor or class must implement a declared interface or help complete a trait.
