### PR TITLE
Add RFC for  Recover blocks with receiver

### DIFF
--- a/text/0000-recover-with-receiver.md
+++ b/text/0000-recover-with-receiver.md
@@ -1,5 +1,5 @@
-- Feature Name: (fill me in with a unique ident, my_awesome_feature)
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Feature Name: recover-with-receiver
+- Start Date: 2020-08-26
 - RFC PR: (leave this empty)
 - Pony Issue: (leave this empty)
 

--- a/text/0000-recover-with-receiver.md
+++ b/text/0000-recover-with-receiver.md
@@ -93,16 +93,23 @@ requiring extra potentially erroring accesses or allocating and swapping new val
 We will add new syntactic forms to allow recover blocks based around an existing receiver expression.
 
 ```
-e.recover | x =>
-   e
+e1.recover | x =>
+   e2[x]
 end
 ```
-and a shorthand
+and shorthands
 ```
-e.recover
-   e
+x.recover
+   e[x]
 end
 ```
+and shorthands
+```
+x.f.recover
+   e[f]
+end
+```
+
 Where in both cases, `e` is an expression, and `x` is a variable binding. In the second case, the first `e` should be either a variable or a field access.
 Inside the body of the recover block, the variable `x` will be bound as a `let` binding. For the shorthand, the name of this variable will be the name
 of the variable that the expression is, or the rightmost field name.

--- a/text/0000-recover-with-receiver.md
+++ b/text/0000-recover-with-receiver.md
@@ -132,7 +132,6 @@ end
 Note that the arguments are evaluated ahead of time, and then consumed. This is how automatic receiver recovery prevents invalidation today, by allowing
 no execution to take place after the receiver has been determined.
 
-For implementation, each recover block will have an optional receiver and a capability of the recover (note that this capability is different than the return capability of a regular recover block). Until the adoption of the more permissive viewpoint adaptation for ephemerals, we will have to treat recover blocks without receiver a special case. A sensible choice would be to mark all such blocks as capability `iso^`. When checking expressions for the recover block, sendability restrictions will be checked relative to the block. Return values would be checked with viewpoint adaptation as specified, except for standard recover blocks, which will use existing rules.
 
 # How We Teach This
 

--- a/text/0000-recover-with-receiver.md
+++ b/text/0000-recover-with-receiver.md
@@ -136,10 +136,10 @@ no execution to take place after the receiver has been determined.
 # How We Teach This
 
 We can refer to this feature as either reciever recovery or recovery with receiver. The section on recover blocks will be modified with an additional section to
-reflect the new type of recover blocks. In this setting we may wish to make a footnote as to `trn` receivers having looser isolation requirements.
-Examples should reflect some of the previously impossible use cases above, as this helps in explaining usage of isolated capabilities in data structures.
+reflect the new type of recover blocks. Examples should reflect some of the previously impossible use cases above, as this helps in explaining usage of isolated capabilities in data structures.
 
-The existing cases of automatic recovery, when calling ref methods, and constructors, will be presented together as conveniences.
+The existing cases of automatic recovery, when calling ref methods, and constructors, will be presented together as conveniences, as it is now a truly representable
+form of recovery.
 
 # How We Test This
 
@@ -158,5 +158,6 @@ We may try to expand automated recovery to handle more cases like the above, at 
 
 # Unresolved questions
 
-The syntax may still need work.
-Research has not fully caught up to more powerful recovery mechanisms as a general detail.
+* The syntax may still need work.
+* Research has not fully caught up to more powerful recovery mechanisms as a general detail.
+* Some methods may be given more flexible types, but these can't be easily expressed generically. Should we add new connectives?

--- a/text/0000-recover-with-receiver.md
+++ b/text/0000-recover-with-receiver.md
@@ -109,15 +109,16 @@ of the variable that the expression is, or the rightmost field name.
 
 The capability of the new binding will depend on the capability of the expression. If it is a unique capability, `iso` or `trn`, then the resulting capability
 will be the strongest aliasable type: `ref`. If it is any self-aliasing capability `k`, then the resulting capability will be `k`.
-Acknowledging that there may be better choices available, at this time `iso^` or `trn^` will take the capability `ref` and act identically to their
-non-ephemeral counterparts. Any variables syntactically present in the receiver expression are considered in-use for the duration of the block and cannot be consumed or re-assigned.
+Acknowledging that there might be better choices available, at this time `iso^` or `trn^` will take the capability `ref` and act identically to their
+non-ephemeral counterparts.
 
-The body of the recover expression will be type-checked similarly to how recover blocks are checked today, with two exceptions. The block will have
-a capability associated with it, and instead of restricting to sendable variable usage, they are restricted to capabilities which are safe-to-write.
-In practice, the only special case here is writing `trn` to `trn. The result of the recover block will be adapted in the the viewpoint of the
-recover block. This subsumes the existing conditions of being either unused or safe to extract.
+To soundly access the outside environment, we must use a few provisions:
+* As in any recover block, the outside environment can be accessed only via sendables
+* All variables which were used in the receiver of the block are considered in-use (and cannot be consumed)
+* To prevent invalidation, the outside environment should be accessed only immutably (though this condition can be loosened for provably disjoint references).
+  This does not prevent consuming `iso` variables to move into the recover block, as they are always disjoint from the receiver.
 
-If the receiver capability is not a unique cap (`iso` or `trn`), then this environment is always treated as `ref` and there are no restrictions on used or returned variables.
+The value which is returned will be viewpoint-adapted according to the capability of the receiver. This subsumes the existing conditions for the returns of automatic receiver recovery.
 
 For a method call to a `ref` method, it is treated as being wrapped in an implicit receiver recovery block. That is,
 `x.f(y, z)` can be de-sugared to `x.recover x.f(y, z) end`, using the shorthand syntax above.

--- a/text/0000-recover-with-receiver.md
+++ b/text/0000-recover-with-receiver.md
@@ -58,7 +58,7 @@ of the variable that the expression is, or the rightmost field name.
 The capability of the new binding will depend on the capability of the expression. If it is a unique capability, `iso` or `trn`, then the resulting capability
 will be the strongest aliasable type: `ref`. If it is any self-aliasing capability `k`, then the resulting capability will be `k`.
 Acknowledging that there may be better choices available, at this time `iso^` or `trn^` will take the capability `ref` and act identically to their
-non-ephemeral counterparts.
+non-ephemeral counterparts. Any variables syntactically present in the receiver expression are considered in-use for the duration of the block and cannot be consumed or re-assigned.
 
 The body of the recover expression will be type-checked similarly to how recover blocks are checked today, with two exceptions. The block will have
 a capability associated with it, and instead of restricting to sendable variable usage, they are restricted to capabilities which are safe-to-write.

--- a/text/0000-recover-with-receiver.md
+++ b/text/0000-recover-with-receiver.md
@@ -120,8 +120,17 @@ To soundly access the outside environment, we must use a few provisions:
 
 The value which is returned will be viewpoint-adapted according to the capability of the receiver. This subsumes the existing conditions for the returns of automatic receiver recovery.
 
-For a method call to a `ref` method, it is treated as being wrapped in an implicit receiver recovery block. That is,
-`x.f(y, z)` can be de-sugared to `x.recover x.f(y, z) end`, using the shorthand syntax above.
+For a method call to a `ref` method, it can be treated as being wrapped in an implicit receiver recovery block. That is,
+`x.f(y, z)` can be de-sugared to:
+```
+let a1 = y
+let a2 = z
+x.recover
+   x.f(consume a1, consume a2)
+end
+```
+Note that the arguments are evaluated ahead of time, and then consumed. This is how automatic receiver recovery prevents invalidation today, by allowing
+no execution to take place after the receiver has been determined.
 
 For implementation, each recover block will have an optional receiver and a capability of the recover (note that this capability is different than the return capability of a regular recover block). Until the adoption of the more permissive viewpoint adaptation for ephemerals, we will have to treat recover blocks without receiver a special case. A sensible choice would be to mark all such blocks as capability `iso^`. When checking expressions for the recover block, sendability restrictions will be checked relative to the block. Return values would be checked with viewpoint adaptation as specified, except for standard recover blocks, which will use existing rules.
 

--- a/text/0000-recover-with-receiver.md
+++ b/text/0000-recover-with-receiver.md
@@ -93,7 +93,7 @@ requiring extra potentially erroring accesses or allocating and swapping new val
 We will add new syntactic forms to allow recover blocks based around an existing receiver expression.
 
 ```
-e.recover as x =>
+e.recover | x =>
    e
 end
 ```


### PR DESCRIPTION
This RFC adds a new syntax to subsume automatic receiver recovery and enable it for more use cases than existing ref methods.

I'm very open to suggestions in syntax, and I could see many variations possible.