### PR TITLE
Corrected Timestamps in several RFCs

### DIFF
--- a/text/0011-upsert-returns-value.md
+++ b/text/0011-upsert-returns-value.md
@@ -1,5 +1,5 @@
 - Feature Name: upsert-returns-value
-- Start Date: YYYY-08-19
+- Start Date: 2016-08-19
 - RFC PR: https://github.com/ponylang/rfcs/pull/27
 - Pony Issue: https://github.com/ponylang/ponyc/issues/1185
 

--- a/text/0034-bare-ffi-lambdas.md
+++ b/text/0034-bare-ffi-lambdas.md
@@ -1,5 +1,5 @@
-- Feature Name: (bare-ffi-lambdas)
-- Start Date: (2017-02-20)
+- Feature Name: bare-ffi-lambdas
+- Start Date: 2017-02-20
 - RFC PR: https://github.com/ponylang/rfcs/pull/79
 - Pony Issue: https://github.com/ponylang/ponyc/issues/1690
 

--- a/text/0048-change-String-join-to-take-iterable.md
+++ b/text/0048-change-String-join-to-take-iterable.md
@@ -1,5 +1,5 @@
 - Feature Name: change-string-join-to-take-iterable
-- Start Date: 2017/07/25
+- Start Date: 2017-07-25
 - RFC PR: https://github.com/ponylang/rfcs/pull/98
 - Pony Issue: https://github.com/ponylang/ponyc/issues/2148
 

--- a/text/0049-improved-itertools-api.md
+++ b/text/0049-improved-itertools-api.md
@@ -1,5 +1,5 @@
 - Feature Name: improved-itertools-api
-- Start Date: 2017-08-8
+- Start Date: 2017-08-08
 - RFC PR: https://github.com/ponylang/rfcs/pull/101
 - Pony Issue: https://github.com/ponylang/ponyc/issues/2189
 

--- a/text/0053-compile-time-expression.md
+++ b/text/0053-compile-time-expression.md
@@ -1,5 +1,5 @@
 - Feature Name: Compile-Time Expressions
-- Start Date: 17/02/2018
+- Start Date: 2018-02-17
 - RFC PR: https://github.com/ponylang/rfcs/pull/120
 - Pony Issue: https://github.com/ponylang/ponyc/issues/2591
 


### PR DESCRIPTION
One RFC was missing a year, the rest had broken or inconsistent formatting.