### PR TITLE
Withdraw RFC 43 (gencap-write)

### DIFF
--- a/text/0000-withdraw-gencap-write.md
+++ b/text/0000-withdraw-gencap-write.md
@@ -1,0 +1,40 @@
+- Feature Name: withdraw-gencap-write
+- Start Date: 2026-09-03
+- RFC PR: https://github.com/ponylang/rfcs/pull/NNNN
+- Pony Issue: https://github.com/ponylang/ponyc/issues/2060
+
+# Summary
+
+Withdraw RFC 43, "gencap-write". The original RFC stays in the repository as a historical record but is no longer an accepted proposal.
+
+# Motivation
+
+RFC 43 was accepted in 2017 and has never been implemented. The original author has since recommended against pursuing the feature, noting that the gencap didn't solve their problem and that the subtle edge cases in generic subtyping make adding new generic caps risky.
+
+No one has needed this feature in the nine years since it was accepted. Leaving it on the accepted list implies the feature is wanted and would be merged if implemented, neither of which is true.
+
+# Detailed design
+
+Add a note to the top of `text/0043-gencap-write.md` recording that the RFC has been withdrawn and pointing to this RFC.
+
+Close ponyc issue #2060 with a comment pointing at this RFC.
+
+# How We Teach This
+
+Nothing to teach. RFC 43 was never implemented and no user code depends on it.
+
+# How We Test This
+
+Nothing to test. No code changes are involved.
+
+# Drawbacks
+
+None. RFC 43 was never implemented and no work is in progress against it.
+
+# Alternatives
+
+Leave RFC 43 on the accepted list. This keeps an "accepted" RFC that no one wants implemented and whose author recommends against it.
+
+# Unresolved questions
+
+None.

--- a/text/0043-gencap-write.md
+++ b/text/0043-gencap-write.md
@@ -3,6 +3,11 @@
 - RFC PR: https://github.com/ponylang/rfcs/pull/93
 - Pony Issue: https://github.com/ponylang/ponyc/issues/2060
 
+# Status
+
+Withdrawn 2026-09-03 by [RFC NNNN](0000-withdraw-gencap-write.md).
+The text below remains as a historical record and does not describe accepted Pony behavior.
+
 # Summary
 
 Add `#write`, a new gencap for use in type parameter constraints, implying the capability set: `{iso, trn, ref}`.

--- a/text/0043-gencap-write.md
+++ b/text/0043-gencap-write.md
@@ -5,7 +5,7 @@
 
 # Status
 
-Withdrawn 2026-09-03 by [RFC NNNN](0000-withdraw-gencap-write.md).
+Withdrawn 2026-09-03 by [RFC 238](0238-withdraw-gencap-write.md).
 The text below remains as a historical record and does not describe accepted Pony behavior.
 
 # Summary

--- a/text/0238-withdraw-gencap-write.md
+++ b/text/0238-withdraw-gencap-write.md
@@ -1,6 +1,6 @@
 - Feature Name: withdraw-gencap-write
 - Start Date: 2026-09-03
-- RFC PR: https://github.com/ponylang/rfcs/pull/NNNN
+- RFC PR: https://github.com/ponylang/rfcs/pull/238
 - Pony Issue: https://github.com/ponylang/ponyc/issues/2060
 
 # Summary


### PR DESCRIPTION
Withdraw RFC 43, "gencap-write". Nine years accepted, never implemented. The original author recommends against pursuing it.

The RFC file stays as a historical record with a withdrawal note at the top. The `0000` filename placeholder will be renamed to match this PR's number once it's assigned.
